### PR TITLE
[US-1594] Fix HTML Encoding Error

### DIFF
--- a/users/login.php
+++ b/users/login.php
@@ -66,7 +66,7 @@ if (!empty($_POST)) {
 
       if (!empty($dest)) {
         $redirect=Input::get('redirect');
-        if(!empty($redirect) || $redirect!=='') Redirect::to($redirect);
+        if(!empty($redirect) || $redirect!=='') Redirect::to(html_entity_decode($redirect));
         else Redirect::to($dest);
       } elseif (file_exists($abs_us_root.$us_url_root.'usersc/scripts/custom_login_script.php')) {
 


### PR DESCRIPTION
Adds html_entity_decode() around the final redirect location to prevent malformed multi-parameter interpretations.

This resolves my previously opened bug report, https://bugs.userspice.com/issue/1594/